### PR TITLE
added a line to the Build section to help with listing dependencies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,10 @@ The MuleFlow Generator uses a two-step translation process:
 ## Build for use as Lib
 `mvn clean install`
 
+## List out dependencies
+`mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=./mydeps`
+
+
 # Implement
 
 The mapper procedure can be called statically using one of four methods in `com.solace.ep.muleflow.MuleFlowGenerator` class. Each of the four methods map AsyncApi to Mule Flow XML the same way. The distinctions are the inputs (AsyncApi File Path or String) and outputs (XML to File or return as String)


### PR DESCRIPTION
Hope you think this is useful.  I needed to figure this out myself for the Eclipse plugin.  Didn't want to use the mega JAR because my code also needed some of the same deps, so it was easier to reference the JARs externally.